### PR TITLE
Implement lead qualification and WhatsApp alert

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # AgenteVendas_Karol
+
+Esta API recebe dados de um agente de vendas, registra as informações no Notion e classifica o nível de qualificação do lead.
+
+## Variáveis de ambiente
+
+- `NOTION_API_KEY` – token de acesso à API do Notion.
+- `NOTION_DATABASE_ID` – ID do banco de dados onde os leads serão armazenados.
+- `ZAPI_URL` – endpoint completo para envio de mensagens pelo Z-API (opcional).
+
+Caso `ZAPI_URL` esteja configurada e o lead seja classificado como **Alto**, uma mensagem é enviada para `5511975578651` informando os detalhes do cliente.
+
+## Regras de qualificação
+
+- **Alto**: cliente mencionou "perdeu o emprego", "oportunidade de emprego" ou "viagem" em sua motivação. Indicações que mencionam perda de emprego também se enquadram aqui.
+- **Médio**: deseja apenas aprimorar o inglês com objetivo de manter o idioma.
+- **Baixo**: quer apenas aprimorar sem objetivo claro.

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI, Request
-import requests, os
+import requests
+import os
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -8,8 +9,41 @@ NOTION_API_KEY   = os.getenv("NOTION_API_KEY")
 NOTION_DATABASE_ID = os.getenv("NOTION_DATABASE_ID")
 NOTION_API_URL   = "https://api.notion.com/v1/pages"
 NOTION_VERSION   = "2022-06-28"
+ZAPI_URL = os.getenv("ZAPI_URL")  # Full endpoint for sending WhatsApp messages
 
 app = FastAPI()
+
+
+def classificar_lead(indicacao: str, motivo: str) -> str:
+    """Classifica o lead de acordo com as regras de qualificação."""
+    texto_motivo = (motivo or "").lower()
+    texto_indicacao = (indicacao or "").lower()
+
+    alto_keywords = ["perdeu o emprego", "oportunidade de emprego", "viagem"]
+    for kw in alto_keywords:
+        if kw in texto_motivo:
+            return "Alto"
+
+    if texto_indicacao and "perdeu" in texto_motivo and "emprego" in texto_motivo:
+        return "Alto"
+
+    if "aprimorar" in texto_motivo:
+        if "manter" in texto_motivo:
+            return "Médio"
+        return "Baixo"
+
+    return "Baixo"
+
+
+def send_whatsapp_message(phone: str, message: str) -> None:
+    """Envia mensagem via Z-API se a URL estiver configurada."""
+    if not ZAPI_URL:
+        return
+    payload = {"phone": phone, "message": message}
+    try:
+        requests.post(ZAPI_URL, json=payload, timeout=10)
+    except Exception as exc:
+        print(f"Erro ao enviar mensagem: {exc}")
 
 @app.get("/")
 async def root():
@@ -27,6 +61,8 @@ async def webhook(request: Request):
     motivo      = data.get('motivo')
     historico   = data.get('historico')
     disponibilidade = data.get('disponibilidade')
+
+    nivel_qualificacao = classificar_lead(indicacao, motivo)
 
     if not all([nome, email, whatsapp]):
         return {"error": "Nome, email ou WhatsApp faltando."}
@@ -77,13 +113,25 @@ async def webhook(request: Request):
                 "rich_text": [
                     { "text": { "content": motivo or "" } }
                 ]
+            },
+            "Nível de Qualificação": {
+                "multi_select": [
+                    {"name": nivel_qualificacao}
+                ]
             }
         }
     }
 
     response = requests.post(NOTION_API_URL, headers=headers, json=payload)
 
+    if nivel_qualificacao == "Alto":
+        mensagem = (
+            "Lead com alta chance de fechar negócio!\n"
+            f"Nome: {nome}\nEmail: {email}\nWhatsApp: {whatsapp}"
+        )
+        send_whatsapp_message("5511975578651", mensagem)
+
     if response.status_code in (200, 201):
         return {"message": "Dados enviados para o Notion com sucesso."}
     else:
-        return {"error": response.text}, response.status_code 
+        return {"error": response.text}, response.status_code


### PR DESCRIPTION
## Summary
- qualify leads by motivation keywords
- add optional Z-API integration for WhatsApp alerts
- store qualification in Notion database
- document new env variable and rules

## Testing
- `python -m py_compile main.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_683f8f4b52b083309f20063269024b5d