### PR TITLE
Implement lead qualification and WhatsApp alert

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
 # AgenteVendas_Karol
+
+Esta API recebe dados de um agente de vendas, registra as informações no Notion e classifica o nível de qualificação do lead.
+
+## Variáveis de ambiente
+
+- `NOTION_API_KEY` – token de acesso à API do Notion.
+- `NOTION_DATABASE_ID` – ID do banco de dados onde os leads serão armazenados.
+- `ZAPI_INSTANCE_ID` – ID da instância para envio de mensagens pelo Z-API.
+- `ZAPI_TOKEN` – token da instância no Z-API.
+- `ZAPI_SECURITY_TOKEN` – token de segurança da conta usado no cabeçalho `Client-Token`.
+- `OPENAI_API_KEY` – chave de API para utilizar o ChatGPT na classificação dos leads (opcional).
+
+Além dos campos básicos (nome, e-mail e WhatsApp), o webhook pode receber a
+`idade` do lead. Esse valor será registrado no Notion e utilizado na geração
+de mensagens personalizadas para leads classificados como **Alto**.
+
+Se todas as variáveis do Z-API estiverem configuradas e o lead for classificado como **Alto**, uma mensagem é enviada para `11975578651`. Quando `OPENAI_API_KEY` está disponível, o texto é gerado pelo ChatGPT explicando por que o contato tem grande chance de fechar negócio.
+
+Se `OPENAI_API_KEY` estiver presente, a classificação utiliza o ChatGPT para avaliar as respostas do lead seguindo as regras abaixo. Caso contrário, a avaliação é feita apenas por regras básicas de palavras-chave.
+
+## Regras de qualificação
+
+- **Alto**: cliente mencionou "perdeu o emprego", "oportunidade de emprego" ou "viagem" em sua motivação. Indicações que mencionam perda de emprego também se enquadram aqui.
+- **Médio**: deseja apenas aprimorar o inglês com objetivo de manter o idioma.
+- **Baixo**: quer apenas aprimorar sem objetivo claro.

--- a/README.md
+++ b/README.md
@@ -9,13 +9,14 @@ Esta API recebe dados de um agente de vendas, registra as informações no Notio
 - `ZAPI_INSTANCE_ID` – ID da instância para envio de mensagens pelo Z-API.
 - `ZAPI_TOKEN` – token da instância no Z-API.
 - `ZAPI_SECURITY_TOKEN` – token de segurança da conta usado no cabeçalho `Client-Token`.
+- `ALERT_PHONE` – número que receberá alertas via WhatsApp.
 - `OPENAI_API_KEY` – chave de API para utilizar o ChatGPT na classificação dos leads (opcional).
 
 Além dos campos básicos (nome, e-mail e WhatsApp), o webhook pode receber a
 `idade` do lead. Esse valor será registrado no Notion e utilizado na geração
 de mensagens personalizadas para leads classificados como **Alto**.
 
-Se todas as variáveis do Z-API estiverem configuradas e o lead for classificado como **Alto**, uma mensagem é enviada para `11975578651`. Quando `OPENAI_API_KEY` está disponível, o texto é gerado pelo ChatGPT explicando por que o contato tem grande chance de fechar negócio.
+Se todas as variáveis do Z-API estiverem configuradas e o lead for classificado como **Alto**, uma mensagem é enviada para o número definido em `ALERT_PHONE`. Quando `OPENAI_API_KEY` está disponível, o texto é gerado pelo ChatGPT explicando por que o contato tem grande chance de fechar negócio.
 
 Se `OPENAI_API_KEY` estiver presente, a classificação utiliza o ChatGPT para avaliar as respostas do lead seguindo as regras abaixo. Caso contrário, a avaliação é feita apenas por regras básicas de palavras-chave.
 
@@ -24,3 +25,21 @@ Se `OPENAI_API_KEY` estiver presente, a classificação utiliza o ChatGPT para a
 - **Alto**: cliente mencionou "perdeu o emprego", "oportunidade de emprego" ou "viagem" em sua motivação. Indicações que mencionam perda de emprego também se enquadram aqui.
 - **Médio**: deseja apenas aprimorar o inglês com objetivo de manter o idioma.
 - **Baixo**: quer apenas aprimorar sem objetivo claro.
+
+## Uso
+
+1. Instale as dependências:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Configure as variáveis de ambiente (pode criar um arquivo `.env` com todas elas).
+3. Inicie o servidor:
+   ```bash
+   uvicorn main:app --reload
+   ```
+4. Envie uma requisição de teste para `/webhook`:
+   ```bash
+   curl -X POST http://localhost:8000/webhook \
+     -H 'Content-Type: application/json' \
+     -d '{"nome": "Maria", "email": "maria@example.com", "whatsapp": "11999999999"}'
+   ```

--- a/main.py
+++ b/main.py
@@ -1,6 +1,8 @@
 from fastapi import FastAPI, Request
-import requests, os
+import requests
+import os
 from dotenv import load_dotenv
+import openai
 
 load_dotenv()
 
@@ -8,8 +10,117 @@ NOTION_API_KEY   = os.getenv("NOTION_API_KEY")
 NOTION_DATABASE_ID = os.getenv("NOTION_DATABASE_ID")
 NOTION_API_URL   = "https://api.notion.com/v1/pages"
 NOTION_VERSION   = "2022-06-28"
+ZAPI_INSTANCE_ID = os.getenv("ZAPI_INSTANCE_ID")
+ZAPI_TOKEN = os.getenv("ZAPI_TOKEN")
+ZAPI_SECURITY_TOKEN = os.getenv("ZAPI_SECURITY_TOKEN")
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-3.5-turbo")
 
 app = FastAPI()
+
+
+def classificar_lead_basico(indicacao: str, motivo: str) -> str:
+    """Classifica o lead utilizando apenas regras simples de palavras-chave."""
+    texto_motivo = (motivo or "").lower()
+    texto_indicacao = (indicacao or "").lower()
+
+    alto_keywords = ["perdeu o emprego", "oportunidade de emprego", "viagem"]
+    for kw in alto_keywords:
+        if kw in texto_motivo:
+            return "Alto"
+
+    if texto_indicacao and "perdeu" in texto_motivo and "emprego" in texto_motivo:
+        return "Alto"
+
+    if "aprimorar" in texto_motivo:
+        if "manter" in texto_motivo:
+            return "Médio"
+        return "Baixo"
+
+    return "Baixo"
+
+
+def classificar_lead(indicacao: str, motivo: str) -> str:
+    """Usa o ChatGPT para qualificar o lead ou aplica as regras básicas."""
+    if OPENAI_API_KEY:
+        openai.api_key = OPENAI_API_KEY
+        prompt = (
+            "Você é um agente de vendas com muitos anos de experiência. "
+            "Classifique o potencial deste lead como Alto, Médio ou Baixo seguindo as regras: "
+            "Alto quando mencionou perda de emprego, oportunidade ou viagem; "
+            "Alto também se houve indicação e perda de emprego; "
+            "Médio quando deseja apenas manter o inglês; "
+            "Baixo quando quer apenas aprimorar sem objetivo claro. "
+            "Responda apenas com uma das palavras: Alto, Médio ou Baixo.\n"
+            f"Indicação: {indicacao}\nMotivação: {motivo}"
+        )
+        try:
+            resp = openai.ChatCompletion.create(
+                model=OPENAI_MODEL,
+                messages=[{"role": "user", "content": prompt}],
+                max_tokens=5,
+                temperature=0
+            )
+            result = resp.choices[0].message.content.strip()
+            if result in {"Alto", "Médio", "Baixo"}:
+                return result
+        except Exception as exc:
+            print(f"Erro ao classificar lead com ChatGPT: {exc}")
+
+    return classificar_lead_basico(indicacao, motivo)
+
+
+def send_whatsapp_message(phone: str, message: str) -> None:
+    """Envia mensagem via Z-API se as variáveis estiverem configuradas."""
+    if not all([ZAPI_INSTANCE_ID, ZAPI_TOKEN, ZAPI_SECURITY_TOKEN]):
+        return
+    url = (
+        f"https://api.z-api.io/instances/{ZAPI_INSTANCE_ID}/"
+        f"token/{ZAPI_TOKEN}/send-text"
+    )
+    headers = {"Client-Token": ZAPI_SECURITY_TOKEN}
+    payload = {"phone": phone, "message": message}
+    try:
+        requests.post(url, json=payload, headers=headers, timeout=10)
+    except Exception as exc:
+        print(f"Erro ao enviar mensagem: {exc}")
+
+
+def gerar_mensagem_alto(nome: str, email: str, whatsapp: str, idade: str,
+                        profissao: str, motivo: str, historico: str) -> str:
+    """Gera mensagem detalhada para leads qualificados."""
+    if OPENAI_API_KEY:
+        openai.api_key = OPENAI_API_KEY
+        prompt = (
+            "Crie um texto curto para o time de vendas explicando por que o lead a seguir "
+            "é considerado de alta qualificação. Utilize as informações fornecidas e cite os "
+            "motivos explicitamente.\n"
+            f"Nome: {nome}\nEmail: {email}\nWhatsApp: {whatsapp}\n"
+            f"Profissão: {profissao}\nIdade: {idade}\nMotivação: {motivo}\n"
+            f"Histórico de Inglês: {historico}"
+        )
+        try:
+            resp = openai.ChatCompletion.create(
+                model=OPENAI_MODEL,
+                messages=[{"role": "user", "content": prompt}],
+                max_tokens=120,
+                temperature=0.7
+            )
+            return resp.choices[0].message.content.strip()
+        except Exception as exc:
+            print(f"Erro ao gerar mensagem com ChatGPT: {exc}")
+
+    partes = [
+        "Lead com alta chance de fechar negócio!",
+        f"Nome: {nome}",
+        f"Email: {email}",
+        f"WhatsApp: {whatsapp}",
+        f"Profissão: {profissao}",
+        f"Idade: {idade}",
+        f"Motivação: {motivo}",
+        f"Histórico: {historico}",
+    ]
+    return "\n".join(partes)
 
 @app.get("/")
 async def root():
@@ -23,10 +134,13 @@ async def webhook(request: Request):
     email       = data.get('email')
     whatsapp    = data.get('whatsapp')
     profissao   = data.get('profissao')
+    idade       = data.get('idade')
     indicacao   = data.get('indicacao')
     motivo      = data.get('motivo')
     historico   = data.get('historico')
     disponibilidade = data.get('disponibilidade')
+
+    nivel_qualificacao = classificar_lead(indicacao, motivo)
 
     if not all([nome, email, whatsapp]):
         return {"error": "Nome, email ou WhatsApp faltando."}
@@ -58,6 +172,11 @@ async def webhook(request: Request):
                     { "text": { "content": indicacao or "" } }
                 ]
             },
+            "Idade": {
+                "rich_text": [
+                    { "text": { "content": str(idade or "") } }
+                ]
+            },
             "Histórico Inglês": {
                 "rich_text": [
                     { "text": { "content": historico or "" } }
@@ -77,13 +196,30 @@ async def webhook(request: Request):
                 "rich_text": [
                     { "text": { "content": motivo or "" } }
                 ]
+            },
+            "Nível de Qualificação": {
+                "multi_select": [
+                    {"name": nivel_qualificacao}
+                ]
             }
         }
     }
 
     response = requests.post(NOTION_API_URL, headers=headers, json=payload)
 
+    if nivel_qualificacao == "Alto":
+        mensagem = gerar_mensagem_alto(
+            nome=nome,
+            email=email,
+            whatsapp=whatsapp,
+            idade=idade,
+            profissao=profissao,
+            motivo=motivo,
+            historico=historico,
+        )
+        send_whatsapp_message("11975578651", mensagem)
+
     if response.status_code in (200, 201):
         return {"message": "Dados enviados para o Notion com sucesso."}
     else:
-        return {"error": response.text}, response.status_code 
+        return {"error": response.text}, response.status_code

--- a/main.py
+++ b/main.py
@@ -13,6 +13,7 @@ NOTION_VERSION   = "2022-06-28"
 ZAPI_INSTANCE_ID = os.getenv("ZAPI_INSTANCE_ID")
 ZAPI_TOKEN = os.getenv("ZAPI_TOKEN")
 ZAPI_SECURITY_TOKEN = os.getenv("ZAPI_SECURITY_TOKEN")
+ALERT_PHONE = os.getenv("ALERT_PHONE", "11975578651")
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-3.5-turbo")
 
@@ -217,7 +218,7 @@ async def webhook(request: Request):
             motivo=motivo,
             historico=historico,
         )
-        send_whatsapp_message("11975578651", mensagem)
+        send_whatsapp_message(ALERT_PHONE, mensagem)
 
     if response.status_code in (200, 201):
         return {"message": "Dados enviados para o Notion com sucesso."}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi==0.109.2
 uvicorn==0.27.1
 requests==2.31.0
 python-dotenv==1.0.1
+openai==1.14.3


### PR DESCRIPTION
## Summary
- qualify leads by motivation keywords
- add optional Z-API integration for WhatsApp alerts
- store qualification in Notion database
- document new env variable and rules
- generate detailed alert message with ChatGPT when available

## Testing
- `python -m py_compile main.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_683f8f4b52b083309f20063269024b5d